### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # full-budget-app
 
-A modular, scalable microservice architecture with best practices of multi-tenancy SaaS platform for managing transactions, budgets, and reviews. using AWS CDK, Lambda, DynamoDB, SQS, and S3.
+A modular, scalable microservice architecture with best practices of a multi-tenancy SaaS platform for managing transactions, budgets, and reviews using AWS CDK, Lambda, DynamoDB, SQS, and S3.
 
 - **GraphQL Apollo** for the API layer
 - **SQS** for event-driven background processing


### PR DESCRIPTION
## Summary
- fix grammar in README introduction

## Testing
- `pnpm build` (fails: rimraf: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a1cab1b1ac8332a7335009775106bd