### PR TITLE
feat(db): add AI tagging fields to DynamoDB

### DIFF
--- a/packages/common/src/abstractions/transactions/transaction-store.ts
+++ b/packages/common/src/abstractions/transactions/transaction-store.ts
@@ -20,5 +20,8 @@ export interface ITransactionStore {
     tenantId: ETenantType,
     transactionId: string,
     matchedCategory: string,
+    taggedBy?: string,
+    confidence?: number,
+    embedding?: number[],
   ): Promise<void>;
 }

--- a/packages/common/src/abstractions/transactions/transaction.ts
+++ b/packages/common/src/abstractions/transactions/transaction.ts
@@ -10,7 +10,9 @@ export interface ITransaction {
   txnDate: string | undefined;
   description?: string;
   category?: string;
+  embedding?: number[];
   taggedBy?: string;
+  confidence?: number;
   type?: string;
   createdAt: string;
   updatedAt?: string;

--- a/packages/db/src/models/transaction-store.ts
+++ b/packages/db/src/models/transaction-store.ts
@@ -57,6 +57,9 @@ export class TransactionStore implements ITransactionStore {
         description: txn.description || "NONE",
         balance: txn.balance,
         category: txn.category,
+        embedding: txn.embedding,
+        taggedBy: txn.taggedBy,
+        confidence: txn.confidence,
         type: txn.type,
       };
 
@@ -143,6 +146,9 @@ export class TransactionStore implements ITransactionStore {
     tenantId: ETenantType,
     transactionId: string,
     matchedCategory: string,
+    taggedBy?: string,
+    confidence?: number,
+    embedding?: number[],
   ): Promise<void> {
     this.logger.info(`Updating transaction category`);
     this.logger.debug("Transaction ID & Category", {
@@ -150,21 +156,41 @@ export class TransactionStore implements ITransactionStore {
       matchedCategory,
     });
 
+    const updateExpressions = ["#category = :cat"];
+    const expressionAttributeNames: Record<string, string> = {
+      "#category": "category",
+    };
+    const expressionAttributeValues: Record<string, any> = {
+      ":cat": matchedCategory,
+    };
+
+    if (taggedBy !== undefined) {
+      updateExpressions.push("#taggedBy = :tagger");
+      expressionAttributeNames["#taggedBy"] = "taggedBy";
+      expressionAttributeValues[":tagger"] = taggedBy;
+    }
+
+    if (confidence !== undefined) {
+      updateExpressions.push("#confidence = :conf");
+      expressionAttributeNames["#confidence"] = "confidence";
+      expressionAttributeValues[":conf"] = confidence;
+    }
+
+    if (embedding !== undefined) {
+      updateExpressions.push("#embedding = :emb");
+      expressionAttributeNames["#embedding"] = "embedding";
+      expressionAttributeValues[":emb"] = embedding;
+    }
+
     const command = new UpdateCommand({
       TableName: this.tableName,
       Key: {
         tenantId,
         transactionId,
       },
-      UpdateExpression: "SET #category = :cat, #taggedBy = :tagger",
-      ExpressionAttributeNames: {
-        "#category": "category",
-        "#taggedBy": "taggedBy",
-      },
-      ExpressionAttributeValues: {
-        ":cat": matchedCategory,
-        ":tagger": matchedCategory ? "RULE_ENGINE" : "AI_TAGGER",
-      },
+      UpdateExpression: `SET ${updateExpressions.join(", ")}`,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
     });
     await this.store.send(command);
     this.logger.info(`Updated category for transaction: ${transactionId}`);

--- a/packages/services/src/transaction-category-service.ts
+++ b/packages/services/src/transaction-category-service.ts
@@ -48,6 +48,8 @@ export class TransactionCategoryService implements ITransactionCategoryService {
 
       // step 2: Match description against rules
       let matchedCategory = this.categorizeByRules(description, rules);
+      let taggedBy = "RULE_ENGINE";
+      let confidence: number | undefined = 1;
       // step 3: Fallback to AI tagging
       if (!matchedCategory) {
         this.logger.info(
@@ -55,12 +57,16 @@ export class TransactionCategoryService implements ITransactionCategoryService {
         );
         // Here you would call your AI tagging service
         matchedCategory = "AI_TAGGED_CATEGORY"; // Placeholder for AI tagging logic
+        taggedBy = "AI_TAGGER";
+        confidence = undefined;
       }
       // step 4: Update transaction with matched category
       await this.transactionStore.updateTransactionCategory(
         tenantId,
         transactionId,
         matchedCategory,
+        taggedBy,
+        confidence,
       );
       this.logger.info(
         `Transaction ${transactionId} categorized as "${matchedCategory}"`,


### PR DESCRIPTION
## Summary
- add optional embedding and confidence fields to transaction model
- persist AI tagging metadata in transaction store updates
- forward tagging details from category service

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68a20c4170788332894ca7db7f313994