### PR TITLE
feat(db): add AI tagging fields to DynamoDB

### DIFF
--- a/packages/common/src/abstractions/transactions/transaction-store.ts
+++ b/packages/common/src/abstractions/transactions/transaction-store.ts
@@ -20,5 +20,8 @@ export interface ITransactionStore {
     tenantId: ETenantType,
     transactionId: string,
     matchedCategory: string,
+    taggedBy?: string,
+    confidence?: number,
+    embedding?: number[],
   ): Promise<void>;
 }

--- a/packages/common/src/abstractions/transactions/transaction.ts
+++ b/packages/common/src/abstractions/transactions/transaction.ts
@@ -10,7 +10,9 @@ export interface ITransaction {
   txnDate: string | undefined;
   description?: string;
   category?: string;
+  embedding?: number[];
   taggedBy?: string;
+  confidence?: number;
   type?: string;
   createdAt: string;
   updatedAt?: string;

--- a/packages/services/src/transaction-category-service.ts
+++ b/packages/services/src/transaction-category-service.ts
@@ -48,6 +48,8 @@ export class TransactionCategoryService implements ITransactionCategoryService {
 
       // step 2: Match description against rules
       let matchedCategory = this.categorizeByRules(description, rules);
+      let taggedBy = "RULE_ENGINE";
+      let confidence: number | undefined = 1;
       // step 3: Fallback to AI tagging
       if (!matchedCategory) {
         this.logger.info(
@@ -55,12 +57,16 @@ export class TransactionCategoryService implements ITransactionCategoryService {
         );
         // Here you would call your AI tagging service
         matchedCategory = "AI_TAGGED_CATEGORY"; // Placeholder for AI tagging logic
+        taggedBy = "AI_TAGGER";
+        confidence = undefined;
       }
       // step 4: Update transaction with matched category
       await this.transactionStore.updateTransactionCategory(
         tenantId,
         transactionId,
         matchedCategory,
+        taggedBy,
+        confidence,
       );
       this.logger.info(
         `Transaction ${transactionId} categorized as "${matchedCategory}"`,


### PR DESCRIPTION
## Summary
- log completion of transaction batches instead of console output
- timestamp category updates and support optional AI metadata
- expand transaction store tests for AI tagging fields

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68a20c4170788332894ca7db7f313994