### PR TITLE
Refactor tag-loaders to include createdAt and AI metadata

### DIFF
--- a/apps/tag-loaders/src/loaders/category-loader.spec.ts
+++ b/apps/tag-loaders/src/loaders/category-loader.spec.ts
@@ -1,0 +1,42 @@
+import { DynamoDBRecord } from "aws-lambda";
+import { mock } from "jest-mock-extended";
+import { ILogger, ITransactionCategoryService, ETenantType } from "@common";
+import { TransactionCategoryLoader } from "./category-loader";
+
+describe("TransactionCategoryLoader", () => {
+  it("should map record to request with createdAt and AI metadata", async () => {
+    const logger = mock<ILogger>();
+    const service = mock<ITransactionCategoryService>();
+    const loader = new TransactionCategoryLoader(logger, service);
+
+    const record = {
+      eventID: "1",
+      eventName: "INSERT",
+      dynamodb: {
+        NewImage: {
+          tenantId: { S: ETenantType.default },
+          transactionId: { S: "t1" },
+          description: { S: "desc" },
+          category: { S: "" },
+          createdAt: { S: "2024-01-01T00:00:00.000Z" },
+          embedding: { L: [{ N: "0.1" }, { N: "0.2" }] },
+          taggedBy: { S: "AI_TAGGER" },
+          confidence: { N: "0.9" },
+        },
+      },
+    } as unknown as DynamoDBRecord;
+
+    await loader.handle([record]);
+
+    expect(service.process).toHaveBeenCalledWith({
+      tenantId: ETenantType.default,
+      transactionId: "t1",
+      description: "desc",
+      category: "",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      embedding: [0.1, 0.2],
+      taggedBy: "AI_TAGGER",
+      confidence: 0.9,
+    });
+  });
+});

--- a/packages/common/src/abstractions/transactions/transaction-category-service.ts
+++ b/packages/common/src/abstractions/transactions/transaction-category-service.ts
@@ -1,5 +1,17 @@
 import { ETenantType } from "../users";
+
+export interface ITransactionCategoryRequest {
+  tenantId: ETenantType;
+  transactionId: string;
+  description?: string;
+  category?: string;
+  createdAt: string;
+  embedding?: number[];
+  taggedBy?: string;
+  confidence?: number;
+}
+
 export interface ITransactionCategoryService {
-  process(request: any): Promise<boolean>;
+  process(request: ITransactionCategoryRequest): Promise<boolean>;
   addRulesByTenant(tenantId: ETenantType): Promise<void>;
 }

--- a/packages/services/src/transaction-category-service.ts
+++ b/packages/services/src/transaction-category-service.ts
@@ -4,6 +4,7 @@ import {
   ITransactionStore,
   ITransactionCategoryService,
   ICategoryRulesStore,
+  ITransactionCategoryRequest,
 } from "@common";
 import { keywordCategoryMap } from "@nlp-tagger";
 
@@ -22,13 +23,19 @@ export class TransactionCategoryService implements ITransactionCategoryService {
     this.categoryRulesStore = categoryRulesStore;
     this.logger.info("ProcessService initialized");
   }
-  public async process(newImage: any): Promise<boolean> {
+  public async process(request: ITransactionCategoryRequest): Promise<boolean> {
     this.logger.info("process started processing messages");
     try {
-      const tenantId = newImage.tenantId?.S;
-      const transactionId = newImage.transactionId?.S;
-      const description = newImage.description?.S;
-      const category = newImage.category?.S;
+      const {
+        tenantId,
+        transactionId,
+        description,
+        category,
+        embedding,
+        taggedBy,
+        confidence,
+      } = request;
+
       if (!tenantId || !transactionId || !description) {
         this.logger.warn("Skipping record with missing required fields", {
           tenantId,
@@ -48,8 +55,9 @@ export class TransactionCategoryService implements ITransactionCategoryService {
 
       // step 2: Match description against rules
       let matchedCategory = this.categorizeByRules(description, rules);
-      let taggedBy = "RULE_ENGINE";
-      let confidence: number | undefined = 1;
+      let finalTaggedBy = taggedBy ?? "RULE_ENGINE";
+      let finalConfidence: number | undefined = confidence ?? 1;
+      let finalEmbedding = embedding;
       // step 3: Fallback to AI tagging
       if (!matchedCategory) {
         this.logger.info(
@@ -57,16 +65,18 @@ export class TransactionCategoryService implements ITransactionCategoryService {
         );
         // Here you would call your AI tagging service
         matchedCategory = "AI_TAGGED_CATEGORY"; // Placeholder for AI tagging logic
-        taggedBy = "AI_TAGGER";
-        confidence = undefined;
+        finalTaggedBy = "AI_TAGGER";
+        finalConfidence = undefined;
+        finalEmbedding = embedding;
       }
       // step 4: Update transaction with matched category
       await this.transactionStore.updateTransactionCategory(
         tenantId,
         transactionId,
         matchedCategory,
-        taggedBy,
-        confidence,
+        finalTaggedBy,
+        finalConfidence,
+        finalEmbedding,
       );
       this.logger.info(
         `Transaction ${transactionId} categorized as "${matchedCategory}"`,


### PR DESCRIPTION
## Summary
- refine transaction category loader to forward createdAt and AI metadata for each record
- define typed request for category processing and adjust service to use it
- cover loader mapping logic with unit test

## Testing
- `pnpm --filter @services test`
- `pnpm exec jest apps/tag-loaders/src/loaders/category-loader.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2cf6764848332be3ad4bcd07ec673