### PR TITLE
feat(nlp-tagger): centralize training config

### DIFF
--- a/packages/nlp-tagger/src/config.spec.ts
+++ b/packages/nlp-tagger/src/config.spec.ts
@@ -1,0 +1,26 @@
+describe("config", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.resetModules();
+  });
+
+  it("uses tiny defaults when NODE_ENV=test", async () => {
+    process.env.NODE_ENV = "test";
+    jest.resetModules();
+    const cfg = await import("./config");
+    expect(cfg.DEFAULT_EPOCHS).toBe(1);
+    expect(cfg.WINDOW_DAYS).toBe(30);
+    expect(cfg.MAX_DATASET_LENGTH).toBe(20);
+  });
+
+  it("uses production defaults otherwise", async () => {
+    process.env.NODE_ENV = "production";
+    jest.resetModules();
+    const cfg = await import("./config");
+    expect(cfg.DEFAULT_EPOCHS).toBe(10);
+    expect(cfg.WINDOW_DAYS).toBe(30);
+    expect(cfg.MAX_DATASET_LENGTH).toBe(Infinity);
+  });
+});

--- a/packages/nlp-tagger/src/config.ts
+++ b/packages/nlp-tagger/src/config.ts
@@ -1,0 +1,11 @@
+const ENV = process.env.NODE_ENV || "development";
+
+export const DEFAULT_EPOCHS = ENV === "test" ? 1 : 10;
+export const WINDOW_DAYS = 30;
+export const MAX_DATASET_LENGTH = ENV === "test" ? 20 : Infinity;
+
+export default {
+  DEFAULT_EPOCHS,
+  WINDOW_DAYS,
+  MAX_DATASET_LENGTH,
+};


### PR DESCRIPTION
## Summary
- add config for nlp-tagger training defaults and test overrides
- cover config behavior with unit tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b8e965808332b84483d235819361